### PR TITLE
[FEATURE] tt_address4 (by typo3friends) compatibilty and doHashFix and fixed templates

### DIFF
--- a/Classes/Controller/AddressController.php
+++ b/Classes/Controller/AddressController.php
@@ -384,7 +384,7 @@ class AddressController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControll
         }
 
         // fix addresses without hash
-        $dofix = false;
+        $dofix = (bool) $this->settings['doHashFix'];
         if ($dofix) {
             $addresslist = $this->addressRepository->findAllByRegisteraddresshash( '' );
             foreach ($addresslist as $fixAddress) {

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -34,6 +34,8 @@ plugin.tx_registeraddress {
 		approveSubject = {$plugin.tx_registeraddress.settings.approveSubject}
 		mailformat = {$plugin.tx_registeraddress.settings.mailformat}
 		sendDeleteApproveMails = {$plugin.tx_registeraddress.settings.sendDeleteApproveMails}
+		# fixes addresses without hash (after migration e.g.) set this to 1 and use editAction, you may deactivate this afterwards
+		doHashFix = 0
 	}
 }
 

--- a/Readme.md
+++ b/Readme.md
@@ -69,7 +69,7 @@ lib.footernewsletter {
     settings < plugin.tx_registeraddress.settings
     
     settings {
-        mainformpageuid = 34
+        pagewithform = 34
     }
 }
 ```

--- a/Resources/Private/Templates/Address/MailNewsletterApproveSuccess.html
+++ b/Resources/Private/Templates/Address/MailNewsletterApproveSuccess.html
@@ -1,3 +1,6 @@
+<p>
 {f:translate(key:'mail.info.greet')} {f:translate(key:'mail.gender.{address.gender}')} {address.firstName} {address.lastName}
-
+</p>
+<p>
 {f:translate(key:'mail.approvesuccess.text')}
+</p>

--- a/Resources/Private/Templates/Address/MailNewsletterApproveSuccess.html
+++ b/Resources/Private/Templates/Address/MailNewsletterApproveSuccess.html
@@ -1,0 +1,3 @@
+{f:translate(key:'mail.info.greet')} {f:translate(key:'mail.gender.{address.gender}')} {address.firstName} {address.lastName}
+
+{f:translate(key:'mail.approvesuccess.text')}

--- a/Resources/Private/Templates/Address/MailNewsletterDeleteSuccess.html
+++ b/Resources/Private/Templates/Address/MailNewsletterDeleteSuccess.html
@@ -1,0 +1,3 @@
+{f:translate(key:'mail.info.greet')} {f:translate(key:'mail.gender.{address.gender}')} {address.firstName} {address.lastName}
+
+{f:translate(key:'mail.deletesuccess.text')}

--- a/Resources/Private/Templates/Address/MailNewsletterDeleteSuccess.html
+++ b/Resources/Private/Templates/Address/MailNewsletterDeleteSuccess.html
@@ -1,3 +1,6 @@
+<p>
 {f:translate(key:'mail.info.greet')} {f:translate(key:'mail.gender.{address.gender}')} {address.firstName} {address.lastName}
-
+</p>
+<p>
 {f:translate(key:'mail.deletesuccess.text')}
+</p>

--- a/Resources/Private/Templates/Address/MailNewsletterInformation.html
+++ b/Resources/Private/Templates/Address/MailNewsletterInformation.html
@@ -1,0 +1,7 @@
+{f:translate(key:'mail.info.greet')} {f:translate(key:'mail.gender.{gender}')} {vorname} {nachname}
+
+{f:translate(key:'mail.info.editLinkText')}
+{f:uri.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+
+{f:translate(key:'mail.info.deleteLinkText')}
+{f:uri.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}

--- a/Resources/Private/Templates/Address/MailNewsletterInformation.html
+++ b/Resources/Private/Templates/Address/MailNewsletterInformation.html
@@ -1,7 +1,11 @@
+<p>
 {f:translate(key:'mail.info.greet')} {f:translate(key:'mail.gender.{gender}')} {vorname} {nachname}
-
+</p>
+<p>
 {f:translate(key:'mail.info.editLinkText')}
 {f:uri.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
-
+</p>
+<p>
 {f:translate(key:'mail.info.deleteLinkText')}
 {f:uri.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+</p>

--- a/Resources/Private/Templates/Address/MailNewsletterRegistration.html
+++ b/Resources/Private/Templates/Address/MailNewsletterRegistration.html
@@ -1,12 +1,18 @@
+<p>
 {f:translate(key:'mail.registration.greet')} {f:translate(key:'mail.gender.{gender}')} {vorname} {nachname}
-
+</p>
+<p>
 {f:translate(key:'mail.registration.text', htmlEscape:0)}
-
+</p>
+<p>
 {f:translate(key:'mail.registration.approveLinkText')}
 {f:uri.action(action: 'approve', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
-
+</p>
+<p>
 {f:translate(key:'mail.registration.deleteLinkText')}
 {f:uri.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
-
+</p>
+<p>
 {f:translate(key:'mail.registration.editLinkText')}
 {f:uri.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+</p>

--- a/Resources/Private/Templates/Address/MailNewsletterRegistration.html
+++ b/Resources/Private/Templates/Address/MailNewsletterRegistration.html
@@ -1,0 +1,12 @@
+{f:translate(key:'mail.registration.greet')} {f:translate(key:'mail.gender.{gender}')} {vorname} {nachname}
+
+{f:translate(key:'mail.registration.text', htmlEscape:0)}
+
+{f:translate(key:'mail.registration.approveLinkText')}
+{f:uri.action(action: 'approve', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+
+{f:translate(key:'mail.registration.deleteLinkText')}
+{f:uri.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+
+{f:translate(key:'mail.registration.editLinkText')}
+{f:uri.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}

--- a/Resources/Private/Templates/Address/MailNewsletterUnsubscribe.html
+++ b/Resources/Private/Templates/Address/MailNewsletterUnsubscribe.html
@@ -1,4 +1,7 @@
+<p>
 {f:translate(key:'mail.info.greet')} {f:translate(key:'mail.gender.{gender}')} {vorname} {nachname}
-
+</p>
+<p>
 {f:translate(key:'mail.info.deleteLinkText')}
-{f:uri.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+{f:uri.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) ->
+</p>

--- a/Resources/Private/Templates/Address/MailNewsletterUnsubscribe.html
+++ b/Resources/Private/Templates/Address/MailNewsletterUnsubscribe.html
@@ -1,0 +1,4 @@
+{f:translate(key:'mail.info.greet')} {f:translate(key:'mail.gender.{gender}')} {vorname} {nachname}
+
+{f:translate(key:'mail.info.deleteLinkText')}
+{f:uri.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}

--- a/Resources/Private/Templates/Address/New.html
+++ b/Resources/Private/Templates/Address/New.html
@@ -16,7 +16,7 @@ Otherwise your changes will be overwritten the next time you save the extension 
 
     <div class="newform">
         <h2><f:translate key="form.new.title" /></h2>
-        <f:form action="create" name="newAddress" object="{newAddress}" pageUid="{settings.mainformpageuid}" pluginName="Registerform">
+        <f:form action="create" name="newAddress" object="{newAddress}" pageUid="{settings.pagewithform}" pluginName="Registerform">
         <f:render partial="Address/FormFields" />
         	<f:form.submit value="{f:translate(key:'form.new.submitButton')}" class="submit" />
         </f:form>

--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,9 @@
     "name": "afm/registeraddress",
     "description": "Register to tt_address package",
     "type": "typo3-cms-extension",
-    "version": "1.0.6",
     "require": {
-        "typo3/cms-core": ">=6.2.0 <8.99.99",
-        "typo3-ter/tt_address": ">=3.1.0 <3.2.99"
+        "typo3/cms-core": ">=8.7,<9.0",
+        "friendsoftypo3/tt-address": ">=4.0"
     },
     "replace": {
         "registeraddress": "self.version"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -30,8 +30,8 @@ $EM_CONF[$_EXTKEY] = array(
 	'version' => '1.0.6',
 	'constraints' => array(
 		'depends' => array(
-			'typo3' => '6.2.0-8.7.99',
-			'tt_address' => '3.1.0-3.2.99',
+			'typo3' => '8.7.0-8.7.99',
+			'tt_address' => '4.0.0-4.0.99',
 		),
 		'conflicts' => array(
 		),


### PR DESCRIPTION
 compatibilty fixes for tt_address 4.0
and introduced a setup variable for doHashFix
as well as some fixes to templates: .html files not found, misnamed mainformpageuid => pagewithform variable

tested, yet raises requirements to TYPO3 8 and tt_address 4