### PR TITLE
[REMOVE]: hidden field with consent, consent is taken from settings

### DIFF
--- a/Classes/Controller/AddressController.php
+++ b/Classes/Controller/AddressController.php
@@ -271,6 +271,7 @@ class AddressController extends ActionController
             $regHash = sha1( $newAddress->getEmail().$rnd );
             $newAddress->setRegisteraddresshash( $regHash );
             $newAddress->setHidden(true);
+            $newAddress->setConsent($this->settings['consent']);
             $this->addressRepository->add($newAddress);
 
             $data = [

--- a/Resources/Private/Partials/Address/FormFields.html
+++ b/Resources/Private/Partials/Address/FormFields.html
@@ -38,5 +38,4 @@
 <div class="fieldrow">
 	<f:translate key="tx_registeraddress_domain_model_address.consent"/>
 	<f:format.html>{settings.consent}</f:format.html>
-	<f:form.hidden property="consent" value="{settings.consent}"/>
 </div>


### PR DESCRIPTION
This avoids user manipulation of the consent text.