### PR TITLE
[BUGFIX] Update hidden addresses without registeraddress-hash

### DIFF
--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -33,6 +33,7 @@ class ext_update
         if (VersionNumberUtility::convertVersionNumberToInteger($typo3Version) >= 8000000) {
             // If TYPO3 version is version 8 or higher
             $this->queryBuilder = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Database\ConnectionPool::class)->getQueryBuilderForTable('tt_address');
+            $this->queryBuilder->getRestrictions()->removeAll()->add(GeneralUtility::makeInstance(DeletedRestriction::class));
         } else {
             // For TYPO3 Version 7 or lower
             $this->databaseConnection = $GLOBALS['TYPO3_DB'];

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -2,6 +2,7 @@
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\VersionNumberUtility;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 
 /**
  * Class ext_update


### PR DESCRIPTION
UpdateWizard for empty registerAddressHashs in TYPO3 8.7. Remove all restrictions from Restrictioncontainer and add only DeletedRestriction.