### PR TITLE
Use real HTML links for HTML mail templates

### DIFF
--- a/Resources/Private/Templates/Address/MailNewsletterInformation.html
+++ b/Resources/Private/Templates/Address/MailNewsletterInformation.html
@@ -1,11 +1,15 @@
+{f:uri.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode() -> f:variable(name: 'editUrl')}
+{f:uri.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode() -> f:variable(name: 'deleteUrl')}
+
+
 <p>
-	{f:translate(key:'mail.info.greet')} {f:translate(key:'mail.gender.{gender}')} {vorname} {nachname}
+    {f:translate(key:'mail.info.greet')} {f:translate(key:'mail.gender.{gender}')} {vorname} {nachname}
 </p>
 <p>
-	{f:translate(key:'mail.info.editLinkText')}
-	{f:uri.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+    {f:translate(key:'mail.info.editLinkText')}
+    <a href="{editUrl}">{editUrl}</a>
 </p>
 <p>
-	{f:translate(key:'mail.info.deleteLinkText')}
-	{f:uri.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+    {f:translate(key:'mail.info.deleteLinkText')}
+    <a href="{deleteUrl}">{deleteUrl}</a>
 </p>

--- a/Resources/Private/Templates/Address/MailNewsletterRegistration.html
+++ b/Resources/Private/Templates/Address/MailNewsletterRegistration.html
@@ -1,22 +1,26 @@
+{f:uri.action(action: 'approve', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode() -> f:variable(name: 'approveUrl')}
+{f:uri.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode() -> f:variable(name: 'deleteUrl')}
+{f:uri.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode() -> f:variable(name: 'editUrl')}
+
 <p>
-	{f:translate(key:'mail.registration.greet')} {f:translate(key:'mail.gender.{gender}')} {vorname} {nachname}
+    {f:translate(key:'mail.registration.greet')} {f:translate(key:'mail.gender.{gender}')} {vorname} {nachname}
 </p>
 <p>
-	{f:translate(key:'mail.registration.text', htmlEscape:0)}
+    {f:translate(key:'mail.registration.text', htmlEscape:0)}
 </p>
 <div>
-	{f:translate(key:'mail.registration.consentText')}
-	{consent -> f:format.html(parseFuncTSPath:"plugin.tx_registeraddress.lib.parseFunc_HTML")}
+    {f:translate(key:'mail.registration.consentText')}
+    {consent -> f:format.html(parseFuncTSPath:"plugin.tx_registeraddress.lib.parseFunc_HTML")}
 </div>
 <p>
-	{f:translate(key:'mail.registration.approveLinkText')}
-	{f:uri.action(action: 'approve', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+    {f:translate(key:'mail.registration.approveLinkText')}
+    <a href="{approveUrl}">{approveUrl}</a>
 </p>
 <p>
-	{f:translate(key:'mail.registration.deleteLinkText')}
-	{f:uri.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+    {f:translate(key:'mail.registration.deleteLinkText')}
+    <a href="{deleteUrl}">{deleteUrl}</a>
 </p>
 <p>
-	{f:translate(key:'mail.registration.editLinkText')}
-	{f:uri.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+    {f:translate(key:'mail.registration.editLinkText')}
+    <a href="{editUrl}">{editUrl}</a>
 </p>

--- a/Resources/Private/Templates/Address/MailNewsletterUnsubscribe.html
+++ b/Resources/Private/Templates/Address/MailNewsletterUnsubscribe.html
@@ -1,7 +1,9 @@
+{f:uri.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode() -> f:variable(name: 'deleteUrl')}
+
 <p>
-	{f:translate(key:'mail.info.greet')} {f:translate(key:'mail.gender.{gender}')} {vorname} {nachname}
+    {f:translate(key:'mail.info.greet')} {f:translate(key:'mail.gender.{gender}')} {vorname} {nachname}
 </p>
 <p>
-	{f:translate(key:'mail.info.deleteLinkText')}
-	{f:uri.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+    {f:translate(key:'mail.info.deleteLinkText')}
+    <a href="{deleteUrl}">{deleteUrl}</a>
 </p>


### PR DESCRIPTION
The HTML mail templates generate URLs for the approve, edit and delete actions. These links are not wrapped with an `<a>` tag, therefore they're not clickable. Since the URLs are needed for the `href` attribute and the link output as well, I saved them into variables.