### PR TITLE
[BUGFIX] add language strings to generate links in HTML emails

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -133,8 +133,14 @@ Versuchen Sie es bitte erneut.</target>
 			<trans-unit id="mail.info.editLinkText" xml:space="preserve">
 				<target>Bitte klicken Sie folgenden Link, um Ihre Daten zu bearbeiten:</target>
 			</trans-unit>
+			<trans-unit id="mail.info.editLink" xml:space="preserve">
+				<target>Daten bearbeiten</target>
+			</trans-unit>
 			<trans-unit id="mail.info.deleteLinkText" xml:space="preserve">
 				<target>Bitte klicken Sie folgenden Link, um Ihre Anmeldung zu löschen:</target>
+			</trans-unit>
+			<trans-unit id="mail.info.deleteLink" xml:space="preserve">
+				<target>Anmeldung löschen</target>
 			</trans-unit>
 			<trans-unit id="mail.info.subjectsuffix" xml:space="preserve">
 				<target>Newsletter-Information</target>
@@ -149,11 +155,20 @@ Versuchen Sie es bitte erneut.</target>
 			<trans-unit id="mail.registration.approveLinkText" xml:space="preserve">
 				<target>Bitte bestätigen Sie Ihre Anmeldung mit Klick auf folgenden Link:</target>
 			</trans-unit>
+			<trans-unit id="mail.registration.approveLink" xml:space="preserve">
+				<target>Anmeldung bestätigen</target>
+			</trans-unit>
 			<trans-unit id="mail.registration.deleteLinkText" xml:space="preserve">
 				<target>Wenn Sie sich nicht für den Newsletter anmelden wollen, dann klicken Sie bitte folgenden Link:</target>
 			</trans-unit>
+			<trans-unit id="mail.registration.deleteLink" xml:space="preserve">
+				<target>Anmeldung widerrufen</target>
+			</trans-unit>
 			<trans-unit id="mail.registration.editLinkText" xml:space="preserve">
 				<target>Wenn Sie Ihre persönlichen Daten ändern wollen, dann klicken Sie bitte folgenden Link:</target>
+			</trans-unit>
+			<trans-unit id="mail.registration.editLink" xml:space="preserve">
+				<target>Daten bearbeiten</target>
 			</trans-unit>
 			<trans-unit id="mail.registration.subjectsuffix" xml:space="preserve">
 				<target>Newsletter-Registrierung</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -133,8 +133,14 @@ Please try again.</source>
 			<trans-unit id="mail.info.editLinkText" xml:space="preserve">
 				<source>Please click the following link to edit your data:</source>
 			</trans-unit>
+			<trans-unit id="mail.info.editLink" xml:space="preserve">
+				<source>Edit data</source>
+			</trans-unit>
 			<trans-unit id="mail.info.deleteLinkText" xml:space="preserve">
 				<source>Please click the following link to delete your registration:</source>
+			</trans-unit>
+			<trans-unit id="mail.info.deleteLink" xml:space="preserve">
+				<source>Delete registration</source>
 			</trans-unit>
 			<trans-unit id="mail.info.subjectsuffix" xml:space="preserve">
 				<source>Newsletter-Information</source>
@@ -149,11 +155,20 @@ Please try again.</source>
 			<trans-unit id="mail.registration.approveLinkText" xml:space="preserve">
 				<source>Please confirm your subscription by clicking on the following link:</source>
 			</trans-unit>
+			<trans-unit id="mail.registration.approveLink" xml:space="preserve">
+				<source>Confirm subscription</source>
+			</trans-unit>
 			<trans-unit id="mail.registration.deleteLinkText" xml:space="preserve">
 				<source>If you do not want to subscribe for the newsletter, please click the following link:</source>
 			</trans-unit>
+			<trans-unit id="mail.registration.deleteLink" xml:space="preserve">
+				<source>Reject subscription</source>
+			</trans-unit>
 			<trans-unit id="mail.registration.editLinkText" xml:space="preserve">
 				<source>If you want to change your personal data, please click the following link:</source>
+			</trans-unit>
+			<trans-unit id="mail.registration.editLink" xml:space="preserve">
+				<target>Update data</target>
 			</trans-unit>
 			<trans-unit id="mail.registration.subjectsuffix" xml:space="preserve">
 				<source>Newsletter-Subscription</source>

--- a/Resources/Private/Templates/Address/MailNewsletterInformation.html
+++ b/Resources/Private/Templates/Address/MailNewsletterInformation.html
@@ -3,9 +3,9 @@
 </p>
 <p>
 	{f:translate(key:'mail.info.editLinkText')}
-	{f:link.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+	{f:translate(key:'mail.info.editLink') -> f:link.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
 </p>
 <p>
 	{f:translate(key:'mail.info.deleteLinkText')}
-	{f:link.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+	{f:translate(key:'mail.info.deleteLink') -> f:link.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
 </p>

--- a/Resources/Private/Templates/Address/MailNewsletterRegistration.html
+++ b/Resources/Private/Templates/Address/MailNewsletterRegistration.html
@@ -10,13 +10,13 @@
 </div>
 <p>
 	{f:translate(key:'mail.registration.approveLinkText')}
-	{f:link.action(action: 'approve', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+	{f:translate(key:'mail.registration.approveLink') -> f:link.action(action: 'approve', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
 </p>
 <p>
 	{f:translate(key:'mail.registration.deleteLinkText')}
-	{f:link.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+	{f:translate(key:'mail.registration.deleteLink') -> f:link.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
 </p>
 <p>
 	{f:translate(key:'mail.registration.editLinkText')}
-	{f:link.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+	{f:translate(key:'mail.registration.editLink') -> f:link.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
 </p>

--- a/Resources/Private/Templates/Address/MailNewsletterUnsubscribe.html
+++ b/Resources/Private/Templates/Address/MailNewsletterUnsubscribe.html
@@ -3,5 +3,5 @@
 </p>
 <p>
 	{f:translate(key:'mail.info.deleteLinkText')}
-	{f:link.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+	{f:translate(key:'mail.info.deleteLink') -> f:link.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
 </p>


### PR DESCRIPTION
The registration and info links in HTML emails were not generated, because of missing text to wrap with a link tag. Sponsored by MEDIPAN GmbH