### PR TITLE
[BUGFIX] refresh field eigene_anrede on update

### DIFF
--- a/Classes/Controller/AddressController.php
+++ b/Classes/Controller/AddressController.php
@@ -592,13 +592,13 @@ class AddressController extends ActionController
     protected function generateEigeneAnrede($address)
     {
         if ($address->getLastName()) {
-            if ($address->getGender() == 'm') {
+            if ($address->getGender() === 'm') {
                 $eigeneAnrede = LocalizationUtility::translate(
                         'salutationgeneration.lastname.m',
                         'registeraddress'
                     ) . $address->getLastName();
 
-            } elseif ($address->getGender() == 'f') {
+            } elseif ($address->getGender() === 'f') {
                 $eigeneAnrede = LocalizationUtility::translate(
                         'salutationgeneration.lastname.f',
                         'registeraddress'

--- a/Classes/Controller/AddressController.php
+++ b/Classes/Controller/AddressController.php
@@ -401,31 +401,7 @@ class AddressController extends ActionController
             $address->setHidden(false);
             $address->setModuleSysDmailHtml(true);
 
-            // create anrede
-            if ( $address->getLastName() ) {
-                if ($address->getGender() == 'm') {
-                    $eigeneAnrede = LocalizationUtility::translate(
-                        'salutationgeneration.lastname.m',
-                        'registeraddress'
-                    ).$address->getLastName();
-
-                } elseif ($address->getGender() == 'f') {
-                    $eigeneAnrede = LocalizationUtility::translate(
-                        'salutationgeneration.lastname.f',
-                        'registeraddress'
-                    ).$address->getLastName();
-                }
-            } elseif ( $address->getFirstName() ) {
-                $eigeneAnrede = LocalizationUtility::translate(
-                    'salutationgeneration.onlyfirstname',
-                    'registeraddress'
-                ).$address->getFirstName();
-            } else {
-                $eigeneAnrede = LocalizationUtility::translate(
-                    'salutationgeneration.other',
-                    'registeraddress'
-                );
-            }
+            $eigeneAnrede = $this->generateEigeneAnrede($address);
             $address->setEigeneAnrede($eigeneAnrede);
 
             $this->addressRepository->update($address);
@@ -602,5 +578,40 @@ class AddressController extends ActionController
         }
         $this->view->assign('address', $address);
         $this->view->assign('doDelete', $doDelete);
+    }
+
+    /**
+     * Generates content for field eigene_anrede
+     *
+     * @param $address
+     * @return string|null
+     */
+    protected function generateEigeneAnrede($address)
+    {
+        if ($address->getLastName()) {
+            if ($address->getGender() == 'm') {
+                $eigeneAnrede = LocalizationUtility::translate(
+                        'salutationgeneration.lastname.m',
+                        'registeraddress'
+                    ) . $address->getLastName();
+
+            } elseif ($address->getGender() == 'f') {
+                $eigeneAnrede = LocalizationUtility::translate(
+                        'salutationgeneration.lastname.f',
+                        'registeraddress'
+                    ) . $address->getLastName();
+            }
+        } elseif ($address->getFirstName()) {
+            $eigeneAnrede = LocalizationUtility::translate(
+                    'salutationgeneration.onlyfirstname',
+                    'registeraddress'
+                ) . $address->getFirstName();
+        } else {
+            $eigeneAnrede = LocalizationUtility::translate(
+                'salutationgeneration.other',
+                'registeraddress'
+            );
+        }
+        return $eigeneAnrede;
     }
 }

--- a/Classes/Controller/AddressController.php
+++ b/Classes/Controller/AddressController.php
@@ -586,7 +586,7 @@ class AddressController extends ActionController
     /**
      * Generates content for field eigene_anrede
      *
-     * @param $address
+     * @param Address $address
      * @return string|null
      */
     protected function generateEigeneAnrede($address)

--- a/Classes/Controller/AddressController.php
+++ b/Classes/Controller/AddressController.php
@@ -486,6 +486,9 @@ class AddressController extends ActionController
         $addressOld = $this->addressRepository->findOneByRegisteraddresshashIgnoreHidden($hash);
         $address->setEmail($addressOld->getEmail());
 
+        $eigeneAnrede = $this->generateEigeneAnrede($address);
+        $address->setEigeneAnrede($eigeneAnrede);
+
         $signalSlotDispatcher = GeneralUtility::makeInstance(Dispatcher::class);
         $signalSlotDispatcher->dispatch(__CLASS__, 'updateBeforePersist', [$address]);
 

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -133,8 +133,14 @@ Versuchen Sie es bitte erneut.</target>
 			<trans-unit id="mail.info.editLinkText" xml:space="preserve">
 				<target>Bitte klicken Sie folgenden Link, um Ihre Daten zu bearbeiten:</target>
 			</trans-unit>
+			<trans-unit id="mail.info.editLink" xml:space="preserve">
+				<target>Daten bearbeiten</target>
+			</trans-unit>
 			<trans-unit id="mail.info.deleteLinkText" xml:space="preserve">
 				<target>Bitte klicken Sie folgenden Link, um Ihre Anmeldung zu löschen:</target>
+			</trans-unit>
+			<trans-unit id="mail.info.deleteLink" xml:space="preserve">
+				<target>Anmeldung löschen</target>
 			</trans-unit>
 			<trans-unit id="mail.info.subjectsuffix" xml:space="preserve">
 				<target>Newsletter-Information</target>
@@ -149,11 +155,20 @@ Versuchen Sie es bitte erneut.</target>
 			<trans-unit id="mail.registration.approveLinkText" xml:space="preserve">
 				<target>Bitte bestätigen Sie Ihre Anmeldung mit Klick auf folgenden Link:</target>
 			</trans-unit>
+			<trans-unit id="mail.registration.approveLink" xml:space="preserve">
+				<target>Anmeldung bestätigen</target>
+			</trans-unit>
 			<trans-unit id="mail.registration.deleteLinkText" xml:space="preserve">
 				<target>Wenn Sie sich nicht für den Newsletter anmelden wollen, dann klicken Sie bitte folgenden Link:</target>
 			</trans-unit>
+			<trans-unit id="mail.registration.deleteLink" xml:space="preserve">
+				<target>Anmeldung widerrufen</target>
+			</trans-unit>
 			<trans-unit id="mail.registration.editLinkText" xml:space="preserve">
 				<target>Wenn Sie Ihre persönlichen Daten ändern wollen, dann klicken Sie bitte folgenden Link:</target>
+			</trans-unit>
+			<trans-unit id="mail.registration.editLink" xml:space="preserve">
+				<target>Daten bearbeiten</target>
 			</trans-unit>
 			<trans-unit id="mail.registration.subjectsuffix" xml:space="preserve">
 				<target>Newsletter-Registrierung</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -133,8 +133,14 @@ Please try again.</source>
 			<trans-unit id="mail.info.editLinkText" xml:space="preserve">
 				<source>Please click the following link to edit your data:</source>
 			</trans-unit>
+			<trans-unit id="mail.info.editLink" xml:space="preserve">
+				<source>Edit data</source>
+			</trans-unit>
 			<trans-unit id="mail.info.deleteLinkText" xml:space="preserve">
 				<source>Please click the following link to delete your registration:</source>
+			</trans-unit>
+			<trans-unit id="mail.info.deleteLink" xml:space="preserve">
+				<source>Delete registration</source>
 			</trans-unit>
 			<trans-unit id="mail.info.subjectsuffix" xml:space="preserve">
 				<source>Newsletter-Information</source>
@@ -149,11 +155,20 @@ Please try again.</source>
 			<trans-unit id="mail.registration.approveLinkText" xml:space="preserve">
 				<source>Please confirm your subscription by clicking on the following link:</source>
 			</trans-unit>
+			<trans-unit id="mail.registration.approveLink" xml:space="preserve">
+				<source>Confirm subscription</source>
+			</trans-unit>
 			<trans-unit id="mail.registration.deleteLinkText" xml:space="preserve">
 				<source>If you do not want to subscribe for the newsletter, please click the following link:</source>
 			</trans-unit>
+			<trans-unit id="mail.registration.deleteLink" xml:space="preserve">
+				<source>Reject subscription</source>
+			</trans-unit>
 			<trans-unit id="mail.registration.editLinkText" xml:space="preserve">
 				<source>If you want to change your personal data, please click the following link:</source>
+			</trans-unit>
+			<trans-unit id="mail.registration.editLink" xml:space="preserve">
+				<target>Update data</target>
 			</trans-unit>
 			<trans-unit id="mail.registration.subjectsuffix" xml:space="preserve">
 				<source>Newsletter-Subscription</source>

--- a/Resources/Private/Templates/Address/MailNewsletterInformation.html
+++ b/Resources/Private/Templates/Address/MailNewsletterInformation.html
@@ -3,9 +3,9 @@
 </p>
 <p>
 	{f:translate(key:'mail.info.editLinkText')}
-	{f:link.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+	{f:translate(key:'mail.info.editLink') -> f:link.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
 </p>
 <p>
 	{f:translate(key:'mail.info.deleteLinkText')}
-	{f:link.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+	{f:translate(key:'mail.info.deleteLink') -> f:link.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
 </p>

--- a/Resources/Private/Templates/Address/MailNewsletterRegistration.html
+++ b/Resources/Private/Templates/Address/MailNewsletterRegistration.html
@@ -10,13 +10,13 @@
 </div>
 <p>
 	{f:translate(key:'mail.registration.approveLinkText')}
-	{f:link.action(action: 'approve', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+	{f:translate(key:'mail.registration.approveLink') -> f:link.action(action: 'approve', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
 </p>
 <p>
 	{f:translate(key:'mail.registration.deleteLinkText')}
-	{f:link.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+	{f:translate(key:'mail.registration.deleteLink') -> f:link.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
 </p>
 <p>
 	{f:translate(key:'mail.registration.editLinkText')}
-	{f:link.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+	{f:translate(key:'mail.registration.editLink') -> f:link.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
 </p>

--- a/Resources/Private/Templates/Address/MailNewsletterUnsubscribe.html
+++ b/Resources/Private/Templates/Address/MailNewsletterUnsubscribe.html
@@ -3,5 +3,5 @@
 </p>
 <p>
 	{f:translate(key:'mail.info.deleteLinkText')}
-	{f:link.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+	{f:translate(key:'mail.info.deleteLink') -> f:link.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
 </p>


### PR DESCRIPTION
The field eigene_anrede wasn't updated if the user updates the data. The more consistent default behaviour will be a refreshed field eigene_anrede. It's still possible to change the field content with the signal. 