### PR TITLE
T3 9x

### DIFF
--- a/Classes/Controller/AddressController.php
+++ b/Classes/Controller/AddressController.php
@@ -35,6 +35,7 @@ use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\CMS\Fluid\View\StandaloneView;
+use TYPO3\CMS\Extbase\Annotation as Extbase;
 
 /**
  *
@@ -235,7 +236,7 @@ class AddressController extends ActionController
      * action form only
      *
      * @param Address $newAddress
-     * @dontvalidate $newAddress
+     * @Extbase\IgnoreValidation("$newAddress")
      * @return void
      */
     public function formOnlyAction(Address $newAddress = NULL)
@@ -247,7 +248,7 @@ class AddressController extends ActionController
      * action new
      *
      * @param Address $newAddress
-     * @dontvalidate $newAddress
+     * @Extbase\IgnoreValidation("$newAddress")
      * @return void
      */
     public function newAction(Address $newAddress = NULL)

--- a/Classes/Controller/AddressController.php
+++ b/Classes/Controller/AddressController.php
@@ -26,6 +26,7 @@ namespace AFM\Registeraddress\Controller;
  ***************************************************************/
 
 use AFM\Registeraddress\Domain\Model\Address;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Mail\MailMessage;
 use TYPO3\CMS\Core\Messaging\AbstractMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -280,6 +281,10 @@ class AddressController extends ActionController
             $newAddress->setRegisteraddresshash( $regHash );
             $newAddress->setHidden(true);
             $newAddress->setConsent($this->settings['consent']);
+
+            $context = GeneralUtility::makeInstance(Context::class);
+            $newAddress->setRegisteraddressLanguage($context->getPropertyFromAspect('language', 'id'));
+
             $this->addressRepository->add($newAddress);
 
             $data = [

--- a/Classes/Domain/Model/Address.php
+++ b/Classes/Domain/Model/Address.php
@@ -124,6 +124,11 @@ class Address extends AbstractEntity
     protected $consent;
 
     /**
+     * @var integer
+     */
+    protected $registeraddressLanguage;
+
+    /**
      * Returns the name
      *
      * @return string
@@ -363,5 +368,20 @@ class Address extends AbstractEntity
         $this->consent = $consent;
     }
 
+    /**
+     * @return int
+     */
+    public function getRegisteraddressLanguage(): int
+    {
+        return $this->registeraddressLanguage;
+    }
+
+    /**
+     * @param int $registeraddressLanguage
+     */
+    public function setRegisteraddressLanguage(int $registeraddressLanguage)
+    {
+        $this->registeraddressLanguage = $registeraddressLanguage;
+    }
 
 }

--- a/Classes/Domain/Model/Address.php
+++ b/Classes/Domain/Model/Address.php
@@ -56,6 +56,7 @@ class Address extends AbstractEntity
      * firstName
      *
      * @var string
+     * @validate NotEmpty
      */
     protected $firstName;
 
@@ -70,6 +71,7 @@ class Address extends AbstractEntity
      * lastName
      *
      * @var string
+     * @validate NotEmpty
      */
     protected $lastName;
 

--- a/Classes/Domain/Repository/AddressRepository.php
+++ b/Classes/Domain/Repository/AddressRepository.php
@@ -47,7 +47,10 @@ class AddressRepository extends Repository
     public function findOneByEmailIgnoreHidden($email)
     {
         $query = $this->createQuery();
-        $query->getQuerySettings()->setIgnoreEnableFields(TRUE);
+        $query->getQuerySettings()->setIgnoreEnableFields(true);
+        $query->getQuerySettings()->setRespectSysLanguage(false);
+        $query->getQuerySettings()->setLanguageOverlayMode(false);
+        $query->getQuerySettings()->setLanguageMode('content_fallback');
 
         $query->matching(
             $query->equals('email', $email )
@@ -66,8 +69,10 @@ class AddressRepository extends Repository
     public function findOneByRegisteraddresshashIgnoreHidden($hash)
     {
         $query = $this->createQuery();
-        $query->getQuerySettings()->setIgnoreEnableFields(TRUE);
-        //$query->getQuerySettings()->setRespectStoragePage(FALSE);
+        $query->getQuerySettings()->setIgnoreEnableFields(true);
+        $query->getQuerySettings()->setRespectSysLanguage(false);
+        $query->getQuerySettings()->setLanguageOverlayMode(false);
+        $query->getQuerySettings()->setLanguageMode('content_fallback');
 
         $query->matching(
             $query->equals('registeraddresshash', $hash )
@@ -104,8 +109,10 @@ class AddressRepository extends Repository
     public function findOneByUidIgnoreHidden($uid)
     {
         $query = $this->createQuery();
-        $query->getQuerySettings()->setIgnoreEnableFields(TRUE);
-        //$query->getQuerySettings()->setRespectStoragePage(FALSE);
+        $query->getQuerySettings()->setIgnoreEnableFields(true);
+        $query->getQuerySettings()->setRespectSysLanguage(false);
+        $query->getQuerySettings()->setLanguageOverlayMode(false);
+        $query->getQuerySettings()->setLanguageMode('content_fallback');
 
         $query->matching(
             $query->equals('uid', $uid )

--- a/Configuration/TCA/Overrides/tx_registeraddress_domain_model_address.php
+++ b/Configuration/TCA/Overrides/tx_registeraddress_domain_model_address.php
@@ -2,28 +2,45 @@
 defined('TYPO3_MODE') or die();
 
 $fields = array(
-    'eigene_anrede' => array(
+    'eigene_anrede' => [
         'exclude' => 0,
         'label' => 'LLL:EXT:registeraddress/Resources/Private/Language/locallang_db.xml:tx_registeraddress_domain_model_address.eigene_anrede',
-        'config' => array(
+        'config' => [
             'type'     => 'input',
             'size'     => 30,
             'eval' => 'trim'
-        ),
-    ),
-    'consent' => array(
+        ],
+    ],
+    'consent' => [
         'exclude' => 0,
         'label' => 'LLL:EXT:registeraddress/Resources/Private/Language/locallang_db.xml:tx_registeraddress_domain_model_address.consent',
-        'config' => array(
+        'config' => [
             'type'     => 'text',
             'readOnly' => 1,
             'size'     => 30,
             'eval' => 'trim'
-        ),
-    ),
+        ],
+    ],
+    'registeraddress_language' => [
+        'exclude' => true,
+        'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.language',
+        'config' => [
+            'type' => 'select',
+            'renderType' => 'selectSingle',
+            'special' => 'languages',
+            'items' => [
+                [
+                    'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
+                    -1,
+                    'flags-multiple'
+                ],
+            ],
+            'default' => 0,
+        ]
+    ]
 );
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tt_address', $fields, TRUE);
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tt_address', 'eigene_anrede', '', 'after:name');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette('tt_address', 'eigene_anrede', '', 'after:name');
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tt_address', 'consent','','after:description');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tt_address', 'consent,registeraddress_language','','after:description');

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -133,8 +133,14 @@ Versuchen Sie es bitte erneut.</target>
 			<trans-unit id="mail.info.editLinkText" xml:space="preserve">
 				<target>Bitte klicken Sie folgenden Link, um Ihre Daten zu bearbeiten:</target>
 			</trans-unit>
+			<trans-unit id="mail.info.editLink" xml:space="preserve">
+				<target>Daten bearbeiten</target>
+			</trans-unit>
 			<trans-unit id="mail.info.deleteLinkText" xml:space="preserve">
 				<target>Bitte klicken Sie folgenden Link, um Ihre Anmeldung zu löschen:</target>
+			</trans-unit>
+			<trans-unit id="mail.info.deleteLink" xml:space="preserve">
+				<target>Anmeldung löschen</target>
 			</trans-unit>
 			<trans-unit id="mail.info.subjectsuffix" xml:space="preserve">
 				<target>Newsletter-Information</target>
@@ -149,11 +155,20 @@ Versuchen Sie es bitte erneut.</target>
 			<trans-unit id="mail.registration.approveLinkText" xml:space="preserve">
 				<target>Bitte bestätigen Sie Ihre Anmeldung mit Klick auf folgenden Link:</target>
 			</trans-unit>
+			<trans-unit id="mail.registration.approveLink" xml:space="preserve">
+				<target>Anmeldung bestätigen</target>
+			</trans-unit>
 			<trans-unit id="mail.registration.deleteLinkText" xml:space="preserve">
 				<target>Wenn Sie sich nicht für den Newsletter anmelden wollen, dann klicken Sie bitte folgenden Link:</target>
 			</trans-unit>
+			<trans-unit id="mail.registration.deleteLink" xml:space="preserve">
+				<target>Anmeldung widerrufen</target>
+			</trans-unit>
 			<trans-unit id="mail.registration.editLinkText" xml:space="preserve">
 				<target>Wenn Sie Ihre persönlichen Daten ändern wollen, dann klicken Sie bitte folgenden Link:</target>
+			</trans-unit>
+			<trans-unit id="mail.registration.editLink" xml:space="preserve">
+				<target>Daten bearbeiten</target>
 			</trans-unit>
 			<trans-unit id="mail.registration.subjectsuffix" xml:space="preserve">
 				<target>Newsletter-Registrierung</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -133,8 +133,14 @@ Please try again.</source>
 			<trans-unit id="mail.info.editLinkText" xml:space="preserve">
 				<source>Please click the following link to edit your data:</source>
 			</trans-unit>
+			<trans-unit id="mail.info.editLink" xml:space="preserve">
+				<source>Edit data</source>
+			</trans-unit>
 			<trans-unit id="mail.info.deleteLinkText" xml:space="preserve">
 				<source>Please click the following link to delete your registration:</source>
+			</trans-unit>
+			<trans-unit id="mail.info.deleteLink" xml:space="preserve">
+				<source>Delete registration</source>
 			</trans-unit>
 			<trans-unit id="mail.info.subjectsuffix" xml:space="preserve">
 				<source>Newsletter-Information</source>
@@ -149,11 +155,20 @@ Please try again.</source>
 			<trans-unit id="mail.registration.approveLinkText" xml:space="preserve">
 				<source>Please confirm your subscription by clicking on the following link:</source>
 			</trans-unit>
+			<trans-unit id="mail.registration.approveLink" xml:space="preserve">
+				<source>Confirm subscription</source>
+			</trans-unit>
 			<trans-unit id="mail.registration.deleteLinkText" xml:space="preserve">
 				<source>If you do not want to subscribe for the newsletter, please click the following link:</source>
 			</trans-unit>
+			<trans-unit id="mail.registration.deleteLink" xml:space="preserve">
+				<source>Reject subscription</source>
+			</trans-unit>
 			<trans-unit id="mail.registration.editLinkText" xml:space="preserve">
 				<source>If you want to change your personal data, please click the following link:</source>
+			</trans-unit>
+			<trans-unit id="mail.registration.editLink" xml:space="preserve">
+				<target>Update data</target>
 			</trans-unit>
 			<trans-unit id="mail.registration.subjectsuffix" xml:space="preserve">
 				<source>Newsletter-Subscription</source>

--- a/Resources/Private/Templates/Address/Approve.html
+++ b/Resources/Private/Templates/Address/Approve.html
@@ -17,7 +17,7 @@ Otherwise your changes will be overwritten the next time you save the extension 
 	<f:then>
 		<f:if condition="{doApprove}">
 			<f:then>
-				<p><f:translate key="form.approve.approvetext" htmlEscape="false" arguments="{0: address.firstName, 1:address.lastName, 2:address.email}" /></p>
+				<p><f:format.raw><f:translate key="form.approve.approvetext" arguments="{0: address.firstName, 1:address.lastName, 2:address.email}" /></f:format.raw></p>
 			</f:then>
 			<f:else>
 				<f:form action="approve" arguments="{hash: hash}">

--- a/Resources/Private/Templates/Address/Create.html
+++ b/Resources/Private/Templates/Address/Create.html
@@ -15,11 +15,11 @@ Otherwise your changes will be overwritten the next time you save the extension 
 	<f:then>
 		<f:if condition="{alreadyExists}">
 			<f:then>
-				<p><f:translate key="form.create.alreadyexists" htmlEscape="false" /><br />
+				<p><f:format.raw><f:translate key="form.create.alreadyexists" /></f:format.raw><br />
 					<f:link.action action="information" arguments="{email: oldAddress.email, uid: oldAddress}" pageUid="{settings.pagewithform}"><f:translate key="form.create.alreadyexistsLinktext" /></f:link.action></p>
 			</f:then>
 			<f:else>
-				<p><f:translate key="form.create.approvetext" htmlEscape="false" arguments="{0: address.email}" /></p>
+				<p><f:format.raw><f:translate key="form.create.approvetext" arguments="{0: address.email}" /></f:format.raw></p>
 			</f:else>
 		</f:if>
 	</f:then>

--- a/Resources/Private/Templates/Address/Delete.html
+++ b/Resources/Private/Templates/Address/Delete.html
@@ -17,7 +17,7 @@ Otherwise your changes will be overwritten the next time you save the extension 
 	<f:then>
 		<f:if condition="{doDelete}">
 			<f:then>
-				<p><f:translate key="form.delete.text" htmlEscape="false" arguments="{0: address.firstName, 1:address.lastName, 2:address.email}" /></p>
+				<p><f:format.raw><f:translate key="form.delete.text" arguments="{0: address.firstName, 1:address.lastName, 2:address.email}" /></f:format.raw></p>
 			</f:then>
 			<f:else>
 				<f:form action="delete" arguments="{hash: hash}">

--- a/Resources/Private/Templates/Address/Information.html
+++ b/Resources/Private/Templates/Address/Information.html
@@ -18,7 +18,7 @@ Otherwise your changes will be overwritten the next time you save the extension 
 		<p><f:translate key="form.info.text" /></p>
 	</f:then>
 	<f:else>
-		<p><f:translate key="form.info.error" htmlEscape="false" /></p>
+		<p><f:format.raw><f:translate key="form.info.error" /></f:format.raw></p>
 	</f:else>
 </f:if>
 

--- a/Resources/Private/Templates/Address/MailNewsletterInformation.html
+++ b/Resources/Private/Templates/Address/MailNewsletterInformation.html
@@ -3,9 +3,9 @@
 </p>
 <p>
 	{f:translate(key:'mail.info.editLinkText')}
-	{f:link.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+	{f:translate(key:'mail.info.editLink') -> f:link.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
 </p>
 <p>
 	{f:translate(key:'mail.info.deleteLinkText')}
-	{f:link.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+	{f:translate(key:'mail.info.deleteLink') -> f:link.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
 </p>

--- a/Resources/Private/Templates/Address/MailNewsletterRegistration.html
+++ b/Resources/Private/Templates/Address/MailNewsletterRegistration.html
@@ -10,13 +10,13 @@
 </div>
 <p>
 	{f:translate(key:'mail.registration.approveLinkText')}
-	{f:link.action(action: 'approve', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+	{f:translate(key:'mail.registration.approveLink') -> f:link.action(action: 'approve', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
 </p>
 <p>
 	{f:translate(key:'mail.registration.deleteLinkText')}
-	{f:link.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+	{f:translate(key:'mail.registration.deleteLink') -> f:link.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
 </p>
 <p>
 	{f:translate(key:'mail.registration.editLinkText')}
-	{f:link.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+	{f:translate(key:'mail.registration.editLink') -> f:link.action(action: 'edit', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
 </p>

--- a/Resources/Private/Templates/Address/MailNewsletterRegistration.html
+++ b/Resources/Private/Templates/Address/MailNewsletterRegistration.html
@@ -2,7 +2,7 @@
 	{f:translate(key:'mail.registration.greet')} {f:translate(key:'mail.gender.{address.gender}')} {address.firstName} {address.lastName}
 </p>
 <p>
-	{f:translate(key:'mail.registration.text', htmlEscape:0)}
+	{f:translate(key:'mail.registration.text')}
 </p>
 <div>
 	{f:translate(key:'mail.registration.consentText')}

--- a/Resources/Private/Templates/Address/MailNewsletterRegistration.txt
+++ b/Resources/Private/Templates/Address/MailNewsletterRegistration.txt
@@ -1,6 +1,6 @@
 {f:translate(key:'mail.registration.greet')} {f:translate(key:'mail.gender.{address.gender}')} {address.firstName} {address.lastName}
 
-{f:translate(key:'mail.registration.text', htmlEscape:0)}
+{f:translate(key:'mail.registration.text')}
 
 {f:translate(key:'mail.registration.consentText')}
 {address.consent -> f:format.html(parseFuncTSPath:"plugin.tx_registeraddress.lib.parseFunc_PLAIN") -> f:format.stripTags()}

--- a/Resources/Private/Templates/Address/MailNewsletterUnsubscribe.html
+++ b/Resources/Private/Templates/Address/MailNewsletterUnsubscribe.html
@@ -3,5 +3,5 @@
 </p>
 <p>
 	{f:translate(key:'mail.info.deleteLinkText')}
-	{f:link.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
+	{f:translate(key:'mail.info.deleteLink') -> f:link.action(action: 'delete', arguments: {hash: hash}, controller: 'Address', extensionName: 'registeraddress', pluginName: 'registerform', noCacheHash: 1, pageUid: settings.pagewithform, absolute: 1) -> f:format.htmlentitiesDecode()}
 </p>

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "require": {
         "typo3/cms-core": ">=6.2.0 <9.99.99",
-        "friendsoftypo3/tt-address": ">=3.1.0 <3.2.99"
+        "friendsoftypo3/tt-address": ">=3.1.0 <4.1.99"
     },
     "replace": {
         "registeraddress": "self.version",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "issues": "https://github.com/lsascha/registeraddress/issues"
     },
     "require": {
-        "typo3/cms-core": ">=6.2.0 <9.99.99",
+        "typo3/cms-core": ">=9.5.0 <9.99.99",
         "friendsoftypo3/tt-address": ">=3.1.0 <4.1.99"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "issues": "https://github.com/lsascha/registeraddress/issues"
     },
     "require": {
-        "typo3/cms-core": ">=6.2.0 <8.99.99",
+        "typo3/cms-core": ">=6.2.0 <9.99.99",
         "friendsoftypo3/tt-address": ">=3.1.0 <3.2.99"
     },
     "replace": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -30,7 +30,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'version' => '2.0.1',
 	'constraints' => array(
 		'depends' => array(
-			'typo3' => '6.2.0-8.7.99',
+			'typo3' => '6.2.0-9.5.99',
 			'tt_address' => '3.1.0-3.3.99',
 		),
 		'conflicts' => array(

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -7,4 +7,5 @@ CREATE TABLE tt_address (
     eigene_anrede varchar(255) DEFAULT '' NOT NULL,
     tx_directmailsubscription_localgender varchar(255) DEFAULT '' NOT NULL,
     consent text,
+    registeraddress_language  int(11) DEFAULT '0' NOT NULL,
 );


### PR DESCRIPTION
compatible version for typo3 9.x, Attention, the extension is not compatible with typo3 <9.x anymore.

Further changes:
- Compatible with tt_address 4.1
- Takes website language into account and saves it in the field "registeraddress_language".
