### PR TITLE
[BUGFIX] Fix exception if argument newAddress is missing

### DIFF
--- a/Classes/Controller/AddressController.php
+++ b/Classes/Controller/AddressController.php
@@ -31,6 +31,10 @@ use AFM\Registeraddress\Event\DeleteBeforePersistEvent;
 use AFM\Registeraddress\Event\UpdateBeforePersistEvent;
 use AFM\Registeraddress\Service\AddressService;
 use AFM\Registeraddress\Service\MailService;
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
+use TYPO3\CMS\Extbase\Http\ForwardResponse;
 use TYPO3\CMS\Extbase\Mvc\Exception\InvalidExtensionNameException;
 use TYPO3\CMS\Extbase\Annotation\IgnoreValidation;
 use Psr\Http\Message\ResponseInterface;
@@ -68,17 +72,21 @@ class AddressController extends ActionController
      */
     protected $addressRepository;
 
+    protected LanguageServiceFactory $languageServiceFactory;
+
     public function __construct(
         AddressRepository $addressRepository,
         PersistenceManager $persistenceManager,
         MailService $mailService,
         AddressService $addressService,
+        LanguageServiceFactory $languageServiceFactory,
     )
     {
         $this->addressRepository = $addressRepository;
         $this->persistenceManager = $persistenceManager;
         $this->mailService = $mailService;
         $this->addressService = $addressService;
+        $this->languageServiceFactory = $languageServiceFactory;
     }
 
     /**
@@ -117,7 +125,10 @@ class AddressController extends ActionController
 
     public function initializeCreateAction(): void
     {
-        $this->eventDispatcher->dispatch(new InitializeCreateActionEvent($this->arguments, $this->request));
+        $newAddress = $this->request->getArguments();
+        if(!$newAddress['newAddress'] === NULL) {
+            $this->eventDispatcher->dispatch(new InitializeCreateActionEvent($this->arguments, $this->request));
+        }
     }
 
     /**
@@ -129,18 +140,22 @@ class AddressController extends ActionController
      * @throws IllegalObjectTypeException
      * @throws InvalidExtensionNameException
      */
-    public function createAction(Address $newAddress): ResponseInterface
+    public function createAction(?Address $newAddress = null): ResponseInterface
     {
-        $oldAddress = $this->addressService->checkIfAddressExists($newAddress->getEmail());
-        if ($oldAddress) {
-            $this->view->assign('oldAddress', $oldAddress);
-            $this->view->assign('alreadyExists', true);
+        if($newAddress === NULL) {
+            return (new ForwardResponse('errorPage'));
         } else {
-            //@todo: avoid double check in AddressService if address exists
-            $this->addressService->createAddress($newAddress);
-        }
+            $oldAddress = $this->addressService->checkIfAddressExists($newAddress->getEmail());
+            if ($oldAddress) {
+                $this->view->assign('oldAddress', $oldAddress);
+                $this->view->assign('alreadyExists', true);
+            } else {
+                //@todo: avoid double check in AddressService if address exists
+                $this->addressService->createAddress($newAddress);
+            }
 
-        $this->view->assign('address', $newAddress);
+            $this->view->assign('address', $newAddress);
+        }
         return $this->htmlResponse();
     }
 
@@ -453,5 +468,23 @@ class AddressController extends ActionController
             );
         }
         return $eigeneAnrede ?? '';
+    }
+
+    public function errorPageAction(): ResponseInterface
+    {
+        $this->addFlashMessage(
+            $this->getTranslatedLabel('LLL:EXT:registeraddress/Resources/Private/Language/locallang.xlf:error.emptyNewAddress.description'),
+            $this->getTranslatedLabel('LLL:EXT:registeraddress/Resources/Private/Language/locallang.xlf:error.emptyNewAddress.title'),
+            ContextualFeedbackSeverity::INFO,
+            false
+        );
+        return $this->htmlResponse();
+    }
+
+    protected function getTranslatedLabel($key): string
+    {
+        $language = $this->request->getAttribute('language') ?? $this->request->getAttribute('site')->getDefaultLanguage();
+        $languageService = $this->languageServiceFactory->createFromSiteLanguage($language);
+        return $languageService->sL($key);
     }
 }

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -216,6 +216,14 @@ Versuchen Sie es bitte erneut.</target>
 				<source>Address already approved.</source>
 				<target>Adresse bereits bestätigt.</target>
 			</trans-unit>
+			<trans-unit id="error.emptyNewAddress.title" xml:space="preserve">
+				<source>Error</source>
+				<target>Fehler</target>
+			</trans-unit>
+			<trans-unit id="error.emptyNewAddress.description" xml:space="preserve">
+				<source>An error occured. New email address is missing. Try it again later.</source>
+				<target>Es ist ein Fehler mit der E-Mailadresse aufgetreten. Bitte versuchen Sie es später noch einmal.</target>
+			</trans-unit>
 
 		</body>
 	</file>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -211,6 +211,12 @@ Please try again.</source>
 			<trans-unit id="alreadyApproved" xml:space="preserve">
 				<source>Address already approved.</source>
 			</trans-unit>
+			<trans-unit id="error.emptyNewAddress.title" xml:space="preserve">
+				<source>Error</source>
+			</trans-unit>
+			<trans-unit id="error.emptyNewAddress.description" xml:space="preserve">
+				<source>An error occured. New email address is missing. Try it again later.</source>
+			</trans-unit>
 
 		</body>
 	</file>

--- a/Resources/Private/Templates/Address/ErrorPage.html
+++ b/Resources/Private/Templates/Address/ErrorPage.html
@@ -1,0 +1,24 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/ViewHelpers"
+			data-namespace-typo3-fluid="true"
+			lang="en">
+<f:layout name="Default" />
+
+<f:section name="main">
+
+
+	<f:flashMessages as="errors">
+		<f:for each="{errors}" as="error">
+			<b>{error.title}</b>
+			<p>{error.message}</p>
+		</f:for>
+	</f:flashMessages>
+
+    <div class="newform">
+        <h2><f:translate extensionName="Registeraddress" key="form.new.title" /></h2>
+        <f:form action="create" name="newAddress" object="{newAddress}" pageUid="{settings.pagewithform}" section="tx-registeraddress" pluginName="Registerform">
+        <f:render partial="Address/FormFields" />
+        	<f:form.submit value="{f:translate(extensionName:'Registeraddress',key:'form.new.submitButton')}" class="submit" />
+        </f:form>
+    </div>
+</f:section>
+</html>


### PR DESCRIPTION
Use errormessageAction to inform the user instead of breaking the page with a TYPO3 exception.

Related: #84